### PR TITLE
inotify: add inodes of file and directory being accessed

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -125,6 +125,18 @@ structs:
         width: 5
         alignment: left
         ellipsis: end
+    - name: i_ino
+      description: 'inode of the file accessed by inotify'
+      attributes:
+        width: 10
+        alignment: left
+        ellipsis: end
+    - name: i_ino_dir
+      description: 'inode of the directory containing the file accessed by inotify'
+      attributes:
+        width: 10
+        alignment: left
+        ellipsis: end
 ebpfParams:
   fanotify_only:
     key: fanotify-only


### PR DESCRIPTION
How to test:

Run in one terminal:
```bash
$ inotifywatch $PWD
```
Run in another terminal:
```bash
$ ls -lid .
12579 drwxr-xr-x 10 alban alban 260 May 27 20:15 . $ touch file1
$ ls -li file1
52719 -rw-r--r-- 1 alban alban 0 May 27 20:15 file1 $ rm file1
```
```
TRACER_COMM  TRACEE_COMM I_MASK  I_WD      I_COOKIE I_INO    I_INO_D… NAME
inotifywatch touch       256     1         0        52719    12579    file1
inotifywatch touch       1342177…1         0        52719    12579    file1
inotifywatch touch       1342177…1         0        52719    12579    file1
inotifywatch touch       1342177…1         0        52719    12579    file1
inotifywatch rm          512     1         0        52719    12579    file1
```
The inodes matches the file and directory.

Fixes https://github.com/alban/fsnotify-enricher/issues/3